### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.22
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+ARG VERSION=0.112.2
 
 RUN apk add --no-cache jq curl && \
-    curl -Lo nu.tgz https://github.com/nushell/nushell/releases/download/0.111.0/nu-0.111.0-x86_64-unknown-linux-musl.tar.gz && \
-    gunzip nu.tgz && \
-    tar xvf nu.tar  && \
-    mv nu-0.111.0-x86_64-unknown-linux-musl/nu /usr/bin 
+    curl -L https://github.com/nushell/nushell/releases/download/${VERSION}/nu-${VERSION}-x86_64-unknown-linux-musl.tar.gz \
+    | tar xzOT <(echo nu-${VERSION}-x86_64-unknown-linux-musl/nu) > /usr/bin/nu && \
+    chmod 755 /usr/bin/nu
     
 
 WORKDIR /opt/test-runner


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.
